### PR TITLE
fix: MemoryPhoto 조회 date 형식 yyyy-MM-dd HH:mm 으로 고정

### DIFF
--- a/src/main/java/com/shallwe/domain/memoryPhoto/presentation/MemoryPhotoController.java
+++ b/src/main/java/com/shallwe/domain/memoryPhoto/presentation/MemoryPhotoController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -31,10 +32,12 @@ public class MemoryPhotoController {
             @ApiResponse(responseCode = "200", description = "MemoryPhoto 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemoryPhotoDetailRes.class))}),
             @ApiResponse(responseCode = "400", description = "MemoryPhoto 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
-    @GetMapping("/{date}")
+    @GetMapping
     public ResponseCustom<?> getMemoryPhotoByDate(
             @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "날짜를 입력해주세요.", required = true) @PathVariable LocalDateTime date
+            @Parameter(description = "날짜를 입력해주세요.[YYYY-MM-DD HH:mm] 형식입니다.", required = true)
+            @RequestParam(value = "date")
+            @DateTimeFormat(pattern="yyyy-MM-dd HH:mm")LocalDateTime date
     ) {
         return ResponseCustom.OK(memoryPhotoService.getMemoryPhotoByDate(userPrincipal, date));
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
MemoryPhoto date 형식 [yyyy-mm-dd hh:mm] 파라미터로 받게 변경
## 스크린샷
![image](https://github.com/ShallWeProject/ShallWeProject_Server/assets/95167215/2f9b25c0-2db2-4951-a3be-929a0223fbed)

## 주의사항
[yyyy-mm-dd hh:mm] 이 형식을 꼭 맞춰야 함
Closes #111 