### PR TITLE
refactor: UserPrinciple로 User 객체 바로 가져올 수 있게 수정

### DIFF
--- a/src/main/java/com/shallwe/domain/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/com/shallwe/domain/auth/application/CustomUserDetailsService.java
@@ -2,21 +2,21 @@ package com.shallwe.domain.auth.application;
 
 import java.util.Optional;
 
-import com.shallwe.global.DefaultAssert;
 import com.shallwe.global.config.security.token.UserPrincipal;
 import com.shallwe.domain.user.domain.User;
 import com.shallwe.domain.user.domain.repository.UserRepository;
 
-import jakarta.transaction.Transactional;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class CustomUserDetailsService implements UserDetailsService{
 
     private final UserRepository userRepository;
@@ -32,12 +32,12 @@ public class CustomUserDetailsService implements UserDetailsService{
         return UserPrincipal.create(user);
     }
 
-    @Transactional
     public UserDetails loadUserById(Long id) {
-        Optional<User> user = userRepository.findById(id);
-        DefaultAssert.isOptionalPresent(user);
+        User user = userRepository.findById(id).
+                orElseThrow(() ->
+                        new UsernameNotFoundException("유저 정보를 찾을 수 없습니다."));
 
-        return UserPrincipal.create(user.get());
+        return UserPrincipal.create(user);
     }
     
 }

--- a/src/main/java/com/shallwe/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/shallwe/domain/user/application/UserServiceImpl.java
@@ -31,8 +31,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserDetailRes getCurrentUser(final UserPrincipal userPrincipal) {
-        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return UserDetailRes.toDto(user);
+        return UserDetailRes.toDto(userPrincipal.getUser());
     }
 
     @Override

--- a/src/main/java/com/shallwe/global/config/security/token/UserPrincipal.java
+++ b/src/main/java/com/shallwe/global/config/security/token/UserPrincipal.java
@@ -7,29 +7,35 @@ import java.util.Map;
 
 import com.shallwe.domain.user.domain.User;
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@Getter
 public class UserPrincipal implements OAuth2User, UserDetails{
+
+    private final User user;
     
-    private Long id;
-    private String email;
-    private String password;
-    private Collection<? extends GrantedAuthority> authorities;
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
     private Map<String, Object> attributes;
 
-    public UserPrincipal(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+    public UserPrincipal(User user, Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.user = user;
         this.id = id;
         this.email = email;
         this.password = password;
         this.authorities = authorities;
     }
 
-    public static UserPrincipal create(User user) {
+    public static UserPrincipal create(final User user) {
         List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getValue()));
         return new UserPrincipal(
+                user,
                 user.getId(),
                 user.getEmail(),
                 user.getPassword(),
@@ -45,14 +51,6 @@ public class UserPrincipal implements OAuth2User, UserDetails{
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
-    }
-    
-    public Long getId() {
-        return id;
-    }
-
-    public String getEmail() {
-        return email;
     }
 
     @Override


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
UserPrinciple로 User 객체 바로 가져올 수 있게 수정
이제 Service Layer에서 User 객체가 필요할 때 UserRepository를 한번 더 갔다오지 않아도 됩니다.
=> 쿼리가 두번 나갈 필요가 없어지게 됐습니다!
## 스크린샷
![image](https://github.com/ShallWeProject/ShallWeProject_Server/assets/95167215/477e58b3-652b-4755-802e-79dd0b1a9b0e)
![image](https://github.com/ShallWeProject/ShallWeProject_Server/assets/95167215/edabf499-5d82-40f3-afee-233ae7580b6e)

## 주의사항

Closes #121 