### PR TITLE
[feat] ShopOwner 엔티티 구현

### DIFF
--- a/src/main/java/com/shallwe/domain/shopowner/domain/ShopOwner.java
+++ b/src/main/java/com/shallwe/domain/shopowner/domain/ShopOwner.java
@@ -1,0 +1,33 @@
+package com.shallwe.domain.shopowner.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Getter
+@Where(clause = "status = 'ACTIVE'")
+public class ShopOwner {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    private String name;
+
+    private String phoneNumber;
+
+    private String password;
+
+    private Boolean marketingConsent;
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/src/main/java/com/shallwe/domain/shopowner/domain/repository/ShopOwnerRepository.java
+++ b/src/main/java/com/shallwe/domain/shopowner/domain/repository/ShopOwnerRepository.java
@@ -1,0 +1,7 @@
+package com.shallwe.domain.shopowner.domain.repository;
+
+import com.shallwe.domain.shopowner.domain.ShopOwner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopOwnerRepository extends JpaRepository<ShopOwner, Long> {
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
ShopOwner 엔티티 구현
## 스크린샷
![image](https://github.com/ShallWeProject/ShallWeProject_Server/assets/95167215/899e6f25-fa42-4ff0-8da5-fc085cdd2f21)

ShopOwner 도메인을 따로 만들어서 구현했습니다.
이유는 다음과 같습니다.
- 유저와 달리 사업자 등록증, 신분증, 통장 사본등 따로 관리해야하는 부분이 있다
- 앱도 따로 사용하는 것이기 때문에 사장 정보 테이블을 따로 두어 이쪽 테이블에서만 사장 앱에서 데이터 조회가 발생하게 해 사장앱과 유저앱의 성능을 동시에 향상할 수 있다.
- 유저와 사장의 비즈니스 로직이 많이 차이가 날 것으로 예상된다.
## 주의사항
찾아보니 사업자 등록증, 신분증, 통장 사본의 정보는 보안을 위해 암호화하거나 S3에 따로 저장해 관리한다는 자료를 보았습니다. 이 부분 상의한번 해보는게 좋을 것 같습니다.
Closes #130 