### PR TITLE
[feat] 관리자 경험 상품 등록 API구현

### DIFF
--- a/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftService.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftService.java
@@ -1,5 +1,6 @@
 package com.shallwe.domain.experiencegift.application;
 
+import com.shallwe.domain.experiencegift.dto.request.AdminExperienceReq;
 import com.shallwe.domain.experiencegift.dto.response.*;
 import com.shallwe.domain.experiencegift.dto.request.ExperienceReq;
 import com.shallwe.domain.experiencegift.dto.response.ExperienceDetailRes;
@@ -33,4 +34,6 @@ public interface ExperienceGiftService {
     ExperienceMainRes mainPage(UserPrincipal userPrincipal);
 
     List<ExperienceRes> getAllPopularGift(UserPrincipal userPrincipal);
+
+    void registerExperienceGift(UserPrincipal userPrincipal, AdminExperienceReq adminExperienceReq);
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/ExpCategory.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/ExpCategory.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Getter
 @Entity
 public class ExpCategory extends BaseEntity {
@@ -17,5 +16,11 @@ public class ExpCategory extends BaseEntity {
 
     private String expCategory;
     private String imageKey;
+
+    @Builder
+    public ExpCategory(String expCategory,String imageKey){
+        this.expCategory=expCategory;
+        this.imageKey=imageKey;
+    }
 
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGift.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGift.java
@@ -2,7 +2,9 @@ package com.shallwe.domain.experiencegift.domain;
 
 
 import com.shallwe.domain.common.BaseEntity;
+import com.shallwe.domain.experiencegift.dto.request.AdminExperienceReq;
 import com.shallwe.domain.shopowner.domain.ShopOwner;
+import com.shallwe.global.utils.AwsS3ImageUrlUtil;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -41,4 +43,19 @@ public class ExperienceGift extends BaseEntity {
     @JoinColumn(name = "shopOwner_id")
     private ShopOwner shopOwner;
 
+    private String location;
+
+    public static ExperienceGift toDto(AdminExperienceReq req, Subtitle subtitle, ExpCategory expCategory, SttCategory sttCategory, ShopOwner shopOwner) {
+        return ExperienceGift.builder()
+                .title(req.getTitle())
+                .subtitle(subtitle)
+                .thumbnail(AwsS3ImageUrlUtil.toUrl(req.getGiftImgUrl()))
+                .price(req.getPrice())
+                .expCategory(expCategory)
+                .sttCategory(sttCategory)
+                .description(req.getDescription())
+                .shopOwner(shopOwner)
+                .location(req.getLocation())
+                .build();
+    }
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/Explanation.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/Explanation.java
@@ -1,12 +1,13 @@
 package com.shallwe.domain.experiencegift.domain;
 
 import com.shallwe.domain.common.BaseEntity;
+import com.shallwe.domain.experiencegift.dto.request.ExplanationReq;
+import com.shallwe.global.utils.AwsS3ImageUrlUtil;
 import jakarta.persistence.*;
 import lombok.*;
 
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Getter
 @Entity
 public class Explanation extends BaseEntity {
@@ -15,11 +16,29 @@ public class Explanation extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long explanationId;
 
+    private String stage;
     private String explanationKey;
     private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="experienceGiftId")
     private ExperienceGift experienceGift;
+
+    @Builder
+    public Explanation(ExperienceGift experienceGift,String stage,String description, String explanationUrl){
+        this.experienceGift=experienceGift;
+        this.stage=stage;
+        this.description=description;
+        this.explanationKey=explanationUrl;
+    }
+
+    public static Explanation toDto(ExplanationReq explanationReq, ExperienceGift experienceGift) {
+        return Explanation.builder()
+                .experienceGift(experienceGift)
+                .stage(explanationReq.getStage())
+                .description(explanationReq.getDescription())
+                .explanationUrl(AwsS3ImageUrlUtil.toUrl(explanationReq.getExplanationUrl()))
+                .build();
+    }
 
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/SttCategory.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/SttCategory.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Getter
 @Entity
 public class SttCategory extends BaseEntity {
@@ -18,4 +17,9 @@ public class SttCategory extends BaseEntity {
     private String sttCategory;
     private String imageKey;
 
+    @Builder
+    public SttCategory(String sttCategory,String imageKey){
+        this.sttCategory=sttCategory;
+        this.imageKey=imageKey;
+    }
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/Subtitle.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/Subtitle.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Getter
 @Entity
 public class Subtitle extends BaseEntity {
@@ -16,5 +15,10 @@ public class Subtitle extends BaseEntity {
     private Long subtitleId;
 
     private String title;
+
+    @Builder
+    public Subtitle(String title) {
+        this.title = title;
+    }
 
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/repository/ExpCategoryRepository.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/repository/ExpCategoryRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface ExpCategoryRepository extends JpaRepository<ExpCategory,Long> {
     Optional<ExpCategory> findByExpCategoryId (long expCategoryId);
+
+    Optional<ExpCategory> findByExpCategory(String expCategory);
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/repository/SttCategoryRepository.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/repository/SttCategoryRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface SttCategoryRepository extends JpaRepository<SttCategory,Long> {
     Optional<SttCategory> findBySttCategoryId (Long sttCategoryId);
+
+    Optional<SttCategory> findBySttCategory(String sttCategory);
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/repository/SubtitleRepository.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/repository/SubtitleRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface SubtitleRepository extends JpaRepository<Subtitle, Long> {
     Optional<Subtitle> findBySubtitleId(Long subtitleId);
+
+    Optional<Subtitle> findByTitle(String subtitle);
 }

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/request/AdminExperienceReq.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/request/AdminExperienceReq.java
@@ -1,0 +1,49 @@
+package com.shallwe.domain.experiencegift.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminExperienceReq {
+    @Schema(type = "String", description = "지역", maxLength = 30)
+    @NotBlank(message = "지역은 필수 입력 값입니다.")
+    private String title;
+
+    @Schema(type = "String", description = "경험 카테고리")
+    private String expCategory;
+
+    @Schema(type = "String", description = "상황 카테고리")
+    private String sttCategory;
+
+    @Schema(type = "String", description = "상품명", maxLength = 100)
+    @NotBlank(message = "상품명은 필수 입력 값입니다.")
+    private String subtitle;
+
+    @Schema(type = "String", description = "썸네일")
+    private String giftImgUrl;
+
+    @Schema(type = "String", description = "상품 설명", maxLength = 256)
+    @NotBlank(message = "상품 설명은 필수 입력 값입니다.")
+    private String description;
+
+    @Schema(type = "List", description = "상품 상세 작성")
+    @NotEmpty(message = "상품 상세 작성은 필수 입력 값입니다.")
+    private List<ExplanationReq> explanation;
+
+    @Schema(type = "String", description = "주소", maxLength = 30)
+    @NotBlank(message = "주소는 필수 입력 값입니다.")
+    private String location;
+
+    @Schema(type = "Long", description = "가격", maxLength = 30)
+    @NotNull(message = "가격은 필수 입력 값입니다.")
+    private Long price;
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/request/ExplanationReq.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/request/ExplanationReq.java
@@ -1,0 +1,14 @@
+package com.shallwe.domain.experiencegift.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExplanationReq {
+    private String stage;
+    private String description;
+    private String explanationUrl;
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceDetailRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceDetailRes.java
@@ -50,7 +50,7 @@ public class ExperienceDetailRes {
         experienceDetailRes.title=experienceGift.getTitle();
         experienceDetailRes.subtitle=experienceGift.getSubtitle().getTitle();
         experienceDetailRes.price=experienceGift.getPrice();
-        experienceDetailRes.explanation=explanations.stream().map(m -> ExplanationRes.toDto(m.getDescription(), m.getExplanationKey())).collect(Collectors.toList());
+        experienceDetailRes.explanation=explanations.stream().map(m -> ExplanationRes.toDto(m.getStage(),m.getDescription(), m.getExplanationKey())).collect(Collectors.toList());
         return experienceDetailRes;
 
     }

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExplanationRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExplanationRes.java
@@ -8,17 +8,20 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor
 public class ExplanationRes {
+    private String stage;
     private String description;
     private String explanationUrl;
 
     @Builder
-    public ExplanationRes(String description,String explanationUrl){
+    public ExplanationRes(String stage,String description,String explanationUrl){
+        this.stage=stage;
         this.description=description;
         this.explanationUrl=explanationUrl;
     }
 
-    public static ExplanationRes toDto(String description,String explanationUrl){
+    public static ExplanationRes toDto(String stage,String description,String explanationUrl){
         return ExplanationRes.builder()
+                .stage(stage)
                 .description(description)
                 .explanationUrl(AwsS3ImageUrlUtil.toUrl(explanationUrl))
                 .build();

--- a/src/main/java/com/shallwe/domain/experiencegift/exception/ChooseOnlyOneCategory.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/exception/ChooseOnlyOneCategory.java
@@ -1,0 +1,5 @@
+package com.shallwe.domain.experiencegift.exception;
+
+public class ChooseOnlyOneCategory extends RuntimeException{
+    public ChooseOnlyOneCategory(){super("경험 카테고리와 상황 카테고리 둘 중 하나만 선택해주세요.");};
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/exception/ExpCategoryAlreadyExist.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/exception/ExpCategoryAlreadyExist.java
@@ -1,0 +1,5 @@
+package com.shallwe.domain.experiencegift.exception;
+
+public class ExpCategoryAlreadyExist extends RuntimeException{
+    public ExpCategoryAlreadyExist(){super("존재하지 않는 경험 카테고리이다.");};
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/exception/SttCategoryAlreadyExist.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/exception/SttCategoryAlreadyExist.java
@@ -1,0 +1,5 @@
+package com.shallwe.domain.experiencegift.exception;
+
+public class SttCategoryAlreadyExist extends RuntimeException{
+    public SttCategoryAlreadyExist(){super("존재하지 않는 상황 카테고리이다.");};
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/presentation/AdminExperienceGiftController.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/presentation/AdminExperienceGiftController.java
@@ -1,0 +1,41 @@
+package com.shallwe.domain.experiencegift.presentation;
+
+import com.shallwe.domain.experiencegift.application.ExperienceGiftServiceImpl;
+import com.shallwe.domain.experiencegift.dto.request.AdminExperienceReq;
+import com.shallwe.domain.experiencegift.dto.response.ExperienceDetailRes;
+import com.shallwe.global.config.security.token.CurrentUser;
+import com.shallwe.global.config.security.token.UserPrincipal;
+import com.shallwe.global.payload.ErrorResponse;
+import com.shallwe.global.payload.ResponseCustom;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin ExperienceGifts", description = "ExperienceGifts API")
+@RequestMapping("/api/v1/admin/experience/gift")
+@RestController
+@RequiredArgsConstructor
+public class AdminExperienceGiftController {
+    private final ExperienceGiftServiceImpl experienceGiftService;
+
+    @Operation(summary = "관리자 경험 선물 등록", description = "관리자 경험 선물 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 경험 선물 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "관리자 경험 선물 등록 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping("/register")
+    public ResponseCustom registerExperienceGift(
+            @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @RequestBody @Valid AdminExperienceReq adminExperienceReq
+            ) {
+        this.experienceGiftService.registerExperienceGift(userPrincipal, adminExperienceReq);
+        return ResponseCustom.OK();
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
-관리자 경험 상품 등록 API구현
-추가로 기존에 경험 상세조회 로직도 추가했습니다. (단계도 조회되도록 ex->1단계, 2단계, 3단계)
## 스크린샷
<img width="687" alt="스크린샷 2023-11-07 오후 12 28 24" src="https://github.com/ShallWeProject/ShallWeProject_Server/assets/90025978/d216d9f9-88be-4036-a1db-8cdb9f1498a0">

## 추가사항
-저희 엔티티에 빌더를 전체 어노테이션으로 달아놔서 id도 빌더로 생성되는데, id는 보이지 않게 다시 수정해야 될 것 같습니다.


Closes #{이슈 번호}