### PR TITLE
[feat] 예약 등록 구현 방식을 변경한다. 

### DIFF
--- a/src/main/java/com/shallwe/domain/memoryphoto/dto/MemoryPhotoDetailRes.java
+++ b/src/main/java/com/shallwe/domain/memoryphoto/dto/MemoryPhotoDetailRes.java
@@ -15,7 +15,9 @@ import java.util.List;
 @Builder
 public class MemoryPhotoDetailRes {
 
-    private LocalDateTime date;
+    private String date;
+
+    private String time;
 
     private String experienceGiftTitle;
 
@@ -25,7 +27,8 @@ public class MemoryPhotoDetailRes {
 
     public static MemoryPhotoDetailRes toDto(Reservation reservation) {
         return MemoryPhotoDetailRes.builder()
-                .date(reservation.getDate())
+                .date(reservation.getDate().toString())
+                .time(reservation.getTime().toString())
                 .experienceGiftTitle(reservation.getExperienceGift().getTitle())
                 .experienceGiftSubTitle(reservation.getExperienceGift().getSubtitle().getTitle())
                 .memoryPhotoImages(reservation.getMemoryPhotos().stream()

--- a/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
+++ b/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
@@ -5,12 +5,14 @@ import com.shallwe.domain.common.BaseEntity;
 import com.shallwe.domain.experiencegift.domain.ExperienceGift;
 import com.shallwe.domain.memoryphoto.domain.MemoryPhoto;
 import com.shallwe.domain.reservation.dto.UpdateReservationReq;
+import com.shallwe.domain.shopowner.domain.ShopOwner;
 import com.shallwe.domain.user.domain.User;
 import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.*;
 import org.hibernate.annotations.Where;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -31,13 +33,20 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "experience_gift_id")
     private ExperienceGift experienceGift;
 
+    @ManyToOne
+    @JoinColumn(name = "owner_id")
+    private ShopOwner owner;
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private User sender;
 
     private Long persons;
 
-    private LocalDateTime date;
+    private LocalDate date;
+
+    private LocalTime time;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id")
@@ -58,10 +67,14 @@ public class Reservation extends BaseEntity {
     public void updateReservation(UpdateReservationReq updateReq) {
         this.persons = Optional.ofNullable(updateReq.getPersons()).orElse(this.persons);
         this.date = Optional.ofNullable(updateReq.getDate()).orElse(this.date);
+        this.time = Optional.ofNullable(LocalTime.of(updateReq.getTime(),0)).orElse(this.time);
         this.receiver = Optional.ofNullable(updateReq.getReceiver()).orElse(this.getReceiver());
         this.phoneNumber = Optional.ofNullable(updateReq.getPhone_number()).orElse(this.phoneNumber);
         this.invitationImg = Optional.ofNullable(updateReq.getInvitation_img()).orElse(this.invitationImg);
         this.invitationComment = Optional.ofNullable(updateReq.getInvitation_comment()).orElse(this.invitationComment);
     }
 
+    public int getHour(){
+        return time.getHour();
+    }
 }

--- a/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
+++ b/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
@@ -67,7 +67,7 @@ public class Reservation extends BaseEntity {
     public void updateReservation(UpdateReservationReq updateReq) {
         this.persons = Optional.ofNullable(updateReq.getPersons()).orElse(this.persons);
         this.date = Optional.ofNullable(updateReq.getDate()).orElse(this.date);
-        this.time = Optional.ofNullable(LocalTime.of(updateReq.getTime(),0)).orElse(this.time);
+        this.time = Optional.ofNullable(updateReq.getTime()).orElse(this.time);
         this.receiver = Optional.ofNullable(updateReq.getReceiver()).orElse(this.getReceiver());
         this.phoneNumber = Optional.ofNullable(updateReq.getPhone_number()).orElse(this.phoneNumber);
         this.invitationImg = Optional.ofNullable(updateReq.getInvitation_img()).orElse(this.invitationImg);

--- a/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
+++ b/src/main/java/com/shallwe/domain/reservation/domain/Reservation.java
@@ -7,7 +7,9 @@ import com.shallwe.domain.memoryphoto.domain.MemoryPhoto;
 import com.shallwe.domain.reservation.dto.UpdateReservationReq;
 import com.shallwe.domain.shopowner.domain.ShopOwner;
 import com.shallwe.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.*;
@@ -31,21 +33,28 @@ public class Reservation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "experience_gift_id")
+    @Schema(description = "선물 ID")
+    @NotBlank
     private ExperienceGift experienceGift;
 
     @ManyToOne
     @JoinColumn(name = "owner_id")
+    @Schema(description = "사장ID")
+    @NotBlank
     private ShopOwner owner;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
+    @Schema(description = "보내는이 ID")
     private User sender;
 
     private Long persons;
 
+    @Schema(description = "예약 날짜, YYYY-DD-MM ")
     private LocalDate date;
 
+    @Schema(description = "예약 시간, HH:MM")
     private LocalTime time;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -59,6 +68,7 @@ public class Reservation extends BaseEntity {
     private String invitationComment;
 
     @Enumerated(EnumType.STRING)
+    @Schema(description = "예약 상태", allowableValues = {"CANCLED","BOOKED","COMPLETED","WAITING","USING"})
     private ReservationStatus reservationStatus;
 
     @OneToMany(mappedBy = "reservation")
@@ -72,6 +82,10 @@ public class Reservation extends BaseEntity {
         this.phoneNumber = Optional.ofNullable(updateReq.getPhone_number()).orElse(this.phoneNumber);
         this.invitationImg = Optional.ofNullable(updateReq.getInvitation_img()).orElse(this.invitationImg);
         this.invitationComment = Optional.ofNullable(updateReq.getInvitation_comment()).orElse(this.invitationComment);
+    }
+
+    public void updateStatus(ReservationStatus status){
+        this.reservationStatus = status;
     }
 
     public int getHour(){

--- a/src/main/java/com/shallwe/domain/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/shallwe/domain/reservation/domain/repository/ReservationRepository.java
@@ -28,6 +28,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("SELECT r FROM Reservation r WHERE r.experienceGift.experienceGiftId = :giftId")
     List<Reservation> findByExperienceGift_Id(@Param("giftId")Long giftId);
 
+    @Query("SELECT r FROM Reservation r WHERE r.experienceGift.experienceGiftId = :giftId and r.status = :BOOKED")
+    List<Reservation> findAllByExperienceGift_IdAndStatus(@Param("giftId")Long giftID);
+
 
     @EntityGraph(attributePaths = {"memoryPhotos"})
     List<Reservation> findAllByDateAndPhoneNumber(LocalDateTime date, String phoneNumber);

--- a/src/main/java/com/shallwe/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/com/shallwe/domain/reservation/dto/ReservationRequest.java
@@ -3,47 +3,83 @@ package com.shallwe.domain.reservation.dto;
 import com.shallwe.domain.experiencegift.domain.ExperienceGift;
 import com.shallwe.domain.reservation.domain.Reservation;
 import com.shallwe.domain.reservation.domain.ReservationStatus;
-import com.shallwe.domain.user.domain.User;
+import com.shallwe.domain.shopowner.domain.ShopOwner;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 import static com.shallwe.domain.reservation.domain.ReservationStatus.BOOKED;
-
+import static com.shallwe.domain.reservation.domain.ReservationStatus.WAITING;
 
 
 @Data
+@NoArgsConstructor
 public class ReservationRequest {
 
-    private Long experienceGiftId;
-    private Long persons;
-    private LocalDateTime date;
-    private String receiverName;
-    private String phoneNumber;
-    private String imageKey;
-    private String invitationComment;
-    private ReservationStatus reservationStatus;
+  private Long experienceGiftId;
+  private Long persons;
+  private Long ownerId;
+  private Map<LocalDate, List<LocalTime>> dateTimeMap;
+  private String phoneNumber;
+  private String imageKey;
+  private String invitationComment;
+  private ReservationStatus reservationStatus;
 
-    public static Reservation toEntity(final ReservationRequest reservationRequest,  User sender,  User receiver,ExperienceGift experienceGift) {
-        System.out.println("receiver = " + receiver);
-        try {
-            Reservation toEntity = Reservation.builder()
-                    .experienceGift(experienceGift)
-                    .sender(sender)
-                    .persons(reservationRequest.getPersons())
-                    .date(reservationRequest.getDate())
-                    .receiver(receiver)
-                    .phoneNumber(reservationRequest.getPhoneNumber())
-                    .invitationImg(reservationRequest.getImageKey())
-                    .invitationComment(reservationRequest.getInvitationComment())
-                    .reservationStatus(BOOKED)
-                    .build();
-            return toEntity;
-        } catch (Exception e) {
-            System.err.println("예외 발생: " + e.getMessage());
-            e.printStackTrace();
-            return null;
-        }
+  public static List<Reservation> toEntityForUser(final ReservationRequest reservationRequest,
+      ExperienceGift experienceGift, ShopOwner owner) {
+    List<Reservation> reservations = new ArrayList<>();
+
+    for (Map.Entry<LocalDate, List<LocalTime>> entry : reservationRequest.getDateTimeMap()
+        .entrySet()) {
+      LocalDate date = entry.getKey();
+      List<LocalTime> times = entry.getValue();
+
+      for (LocalTime time : times) {
+        Reservation toEntity = Reservation.builder()
+            .experienceGift(experienceGift)
+            .persons(reservationRequest.getPersons())
+            .date(date)
+            .time(time)
+            .owner(owner)
+            .phoneNumber(reservationRequest.getPhoneNumber())
+            .invitationImg(reservationRequest.getImageKey())
+            .invitationComment(reservationRequest.getInvitationComment())
+            .reservationStatus(BOOKED)
+            .build();
+
+        reservations.add(toEntity);
+      }
     }
+    return reservations;
+  }
+
+  public static List<Reservation> toEntityForOwner(ReservationRequest reservationRequest,
+      ExperienceGift experienceGift,ShopOwner owner) {
+    List<Reservation> reservations = new ArrayList<>();
+
+    for (Map.Entry<LocalDate, List<LocalTime>> entry : reservationRequest.getDateTimeMap()
+        .entrySet()) {
+      LocalDate date = entry.getKey();
+      List<LocalTime> times = entry.getValue();
+
+      for (LocalTime time : times) {
+        Reservation toEntity = Reservation.builder()
+            .experienceGift(experienceGift)
+            .date(date)
+            .time(time)
+            .owner(owner)
+            .reservationStatus(WAITING)
+            .build();
+
+        reservations.add(toEntity);
+      }
+    }
+
+    return reservations;
+  }
+
 }
 

--- a/src/main/java/com/shallwe/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/shallwe/domain/reservation/dto/ReservationResponse.java
@@ -3,74 +3,59 @@ package com.shallwe.domain.reservation.dto;
 import com.shallwe.domain.reservation.domain.Reservation;
 import com.shallwe.domain.reservation.domain.ReservationStatus;
 import com.shallwe.global.utils.AwsS3ImageUrlUtil;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
-@RequiredArgsConstructor
+
 @Data
+@AllArgsConstructor
+@Builder
 public class ReservationResponse {
 
-    private Long id;
-    private Long senderId;
-    private String sender;
-    private Long persons;
-    private LocalDateTime date;
-    private Long experienceGiftId;
-    private String receiver;
-    private String phoneNumber;
-    private String invitationImageURL;
-    private String invitationComment;
-    private ReservationStatus reservationStatus;
+  private Long id;
+  private Long senderId;
+  private Long ownerId;
+  private String sender;
+  private Long persons;
+  private String date;
+  private String time;
+  private Long experienceGiftId;
+  private String receiver;
+  private String phoneNumber;
+  private String invitationImageURL;
+  private String invitationComment;
+  private ReservationStatus reservationStatus;
 
-    @Builder
-    public ReservationResponse(Long id, Long senderId, String sender, Long persons, LocalDateTime date, Long experienceGiftId, String receiver, String phoneNumber, String invitationImageURL, String invitationComment, ReservationStatus reservationStatus) {
-        this.id = id;
-        this.senderId = senderId;
-        this.sender = sender;
-        this.persons = persons;
-        this.date = date;
-        this.experienceGiftId = experienceGiftId;
-        this.receiver = receiver;
-        this.phoneNumber = phoneNumber;
-        this.invitationImageURL = invitationImageURL;
-        this.invitationComment = invitationComment;
-        this.reservationStatus = reservationStatus;
-    }
 
-    public static ReservationResponse toDto(Reservation reservation) {
-        ReservationResponseBuilder builder = ReservationResponse.builder()
-                .id(reservation.getId())
-                .experienceGiftId(reservation.getExperienceGift().getExperienceGiftId())
-                .senderId(reservation.getSender().getId())
-                .sender(reservation.getSender().getName())
-                .persons(reservation.getPersons())
-                .date(reservation.getDate())
-                .phoneNumber(reservation.getPhoneNumber())
-                .receiver(reservation.getReceiver().getName())
-                .invitationImageURL(AwsS3ImageUrlUtil.toUrl(reservation.getInvitationImg()))
-                .invitationComment(reservation.getInvitationComment())
-                .reservationStatus(reservation.getReservationStatus());
+  public static ReservationResponse toDtoUser(Reservation reservation) {
+    ReservationResponseBuilder builder = ReservationResponse.builder()
+        .id(reservation.getId())
+        .experienceGiftId(reservation.getExperienceGift().getExperienceGiftId())
+        .senderId(reservation.getSender().getId())
+        .ownerId(reservation.getOwner().getId())
+        .sender(reservation.getSender().getName())
+        .persons(reservation.getPersons())
+        .date(reservation.getDate().toString())
+        .time(reservation.getTime().toString())
+        .phoneNumber(reservation.getPhoneNumber())
+        .receiver(reservation.getReceiver().getName())
+        .invitationImageURL(AwsS3ImageUrlUtil.toUrl(reservation.getInvitationImg()))
+        .invitationComment(reservation.getInvitationComment())
+        .reservationStatus(reservation.getReservationStatus());
 
-        return builder.build();
-    }
+    return builder.build();
+  }
 
-    public static ReservationResponse fromReservation(Reservation reservation) {
-        ReservationResponse reservationResponse = new ReservationResponse();
-        reservationResponse.setId(reservation.getId());
-        reservationResponse.setSenderId(reservation.getSender().getId());
-        reservationResponse.setSender(reservation.getSender().getName());
-        reservationResponse.setPersons(reservation.getPersons());
-        reservationResponse.setDate(reservation.getDate());
-        reservationResponse.setExperienceGiftId(reservation.getExperienceGift().getExperienceGiftId());
-        reservationResponse.setReceiver(reservation.getReceiver().getName());
-        reservationResponse.setPhoneNumber(reservation.getPhoneNumber());
-        reservationResponse.setInvitationImageURL(AwsS3ImageUrlUtil.toUrl(reservation.getInvitationImg()));
-        reservationResponse.setInvitationComment(reservation.getInvitationComment());
-        reservationResponse.setReservationStatus(reservation.getReservationStatus());
+  public static ReservationResponse toDtoOwner(Reservation reservation) {
+    ReservationResponseBuilder builder = ReservationResponse.builder()
+        .id(reservation.getId())
+        .experienceGiftId(reservation.getExperienceGift().getExperienceGiftId())
+        .date(reservation.getDate().toString())
+        .time(reservation.getTime().toString())
+        .reservationStatus(reservation.getReservationStatus());
 
-        return reservationResponse;
-    }
-
+    return builder.build();
+  }
 }

--- a/src/main/java/com/shallwe/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/shallwe/domain/reservation/dto/ReservationResponse.java
@@ -52,6 +52,7 @@ public class ReservationResponse {
     ReservationResponseBuilder builder = ReservationResponse.builder()
         .id(reservation.getId())
         .experienceGiftId(reservation.getExperienceGift().getExperienceGiftId())
+        .ownerId(reservation.getOwner().getId())
         .date(reservation.getDate().toString())
         .time(reservation.getTime().toString())
         .reservationStatus(reservation.getReservationStatus());

--- a/src/main/java/com/shallwe/domain/reservation/dto/UpdateReservationReq.java
+++ b/src/main/java/com/shallwe/domain/reservation/dto/UpdateReservationReq.java
@@ -2,11 +2,9 @@ package com.shallwe.domain.reservation.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.shallwe.domain.user.domain.User;
-import jakarta.validation.constraints.FutureOrPresent;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.Data;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
 
 
 @Data
@@ -14,8 +12,8 @@ public class UpdateReservationReq {
 
     private Long id;
     private Long persons;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING)
-    private LocalDateTime date;
+    private LocalDate date;
+    private LocalTime time;
     private User sender;
     private User receiver;
     private String phone_number;

--- a/src/main/java/com/shallwe/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/shallwe/domain/reservation/presentation/ReservationController.java
@@ -1,7 +1,6 @@
 package com.shallwe.domain.reservation.presentation;
 
 import com.shallwe.domain.reservation.application.ReservationServiceImpl;
-import com.shallwe.domain.reservation.domain.Reservation;
 import com.shallwe.domain.reservation.dto.DeleteReservationRes;
 import com.shallwe.domain.reservation.dto.ReservationRequest;
 import com.shallwe.domain.reservation.dto.ReservationResponse;
@@ -74,11 +73,11 @@ public class ReservationController {
             @ApiResponse(responseCode = "400", description = "예약 생성 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))} )
     })
     @PostMapping
-    public ResponseCustom<ReservationResponse> createReservation(
+    public ResponseCustom<List<ReservationResponse>> createReservation(
             @Parameter(description = "예약 요청을 확인해주세요.", required = true) @RequestBody ReservationRequest reservationRequest,
             @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
     ){
-        return ResponseCustom.CREATED(reservationServiceimpl.addReservation(reservationRequest,userPrincipal));
+        return ResponseCustom.CREATED(reservationServiceimpl.addOwnerReservation(reservationRequest,userPrincipal));
     }
 
     @Operation(summary ="예약 수정하기", description = "예약을 수정합니다")

--- a/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerService.java
+++ b/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerService.java
@@ -1,6 +1,7 @@
 package com.shallwe.domain.shopowner.application;
 
 import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
+import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
 import com.shallwe.domain.user.dto.DeleteUserRes;
 import com.shallwe.global.config.security.token.UserPrincipal;
 import com.shallwe.global.payload.Message;
@@ -9,6 +10,7 @@ public interface ShopOwnerService {
 
     Message shopOwnerChangePassword(UserPrincipal userPrincipal, ShopOwnerChangePasswordReq shopOwnerChangePasswordReq);
     Message deleteCurrentShopOwner(UserPrincipal userPrincipal);
-
+    ShopOwnerGiftManageRes getShopOwnerReservation(UserPrincipal userPrincipal, Long giftId);
+    Message confirmPayment(UserPrincipal userPrincipal, Long reservationId);
 }
 

--- a/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerServiceImpl.java
+++ b/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerServiceImpl.java
@@ -4,14 +4,22 @@ package com.shallwe.domain.shopowner.application;
 import com.shallwe.domain.auth.domain.Token;
 import com.shallwe.domain.auth.domain.repository.TokenRepository;
 import com.shallwe.domain.common.Status;
+import com.shallwe.domain.experiencegift.domain.ExperienceGift;
+import com.shallwe.domain.experiencegift.domain.repository.ExperienceGiftRepository;
+import com.shallwe.domain.experiencegift.exception.ExperienceGiftNotFoundException;
+import com.shallwe.domain.reservation.domain.Reservation;
+import com.shallwe.domain.reservation.domain.repository.ReservationRepository;
 import com.shallwe.domain.shopowner.domain.ShopOwner;
 import com.shallwe.domain.shopowner.domain.repository.ShopOwnerRepository;
+import com.shallwe.domain.shopowner.dto.ShopOwnerReservationRes;
 import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
+import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
 import com.shallwe.domain.shopowner.exception.InvalidShopOwnerException;
-import com.shallwe.domain.user.domain.User;
 import com.shallwe.domain.user.exception.InvalidTokenException;
 import com.shallwe.global.config.security.token.UserPrincipal;
 import com.shallwe.global.payload.Message;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,36 +30,52 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ShopOwnerServiceImpl implements ShopOwnerService {
 
-    private final PasswordEncoder passwordEncoder;
-    private final ShopOwnerRepository shopOwnerRepository;
-    private final TokenRepository tokenRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final ShopOwnerRepository shopOwnerRepository;
+  private final TokenRepository tokenRepository;
+  private final ReservationRepository reservationRepository;
+  private final ExperienceGiftRepository experienceGiftRepository;
 
-    @Override
-    @Transactional
-    public Message shopOwnerChangePassword(final UserPrincipal userPrincipal, final ShopOwnerChangePasswordReq shopOwnerChangePasswordReq) {
-        ShopOwner shopOwner = shopOwnerRepository.findById(userPrincipal.getId())
-                .orElseThrow(InvalidShopOwnerException::new);
+  @Override
+  @Transactional
+  public Message shopOwnerChangePassword(final UserPrincipal userPrincipal,
+      final ShopOwnerChangePasswordReq shopOwnerChangePasswordReq) {
+    ShopOwner shopOwner = shopOwnerRepository.findById(userPrincipal.getId())
+        .orElseThrow(InvalidShopOwnerException::new);
 
-        shopOwner.changePassword(passwordEncoder.encode(shopOwnerChangePasswordReq.getChangePassword()));
+    shopOwner.changePassword(
+        passwordEncoder.encode(shopOwnerChangePasswordReq.getChangePassword()));
 
-        return Message.builder()
-                .message("비밀번호가 변경되었습니다.").build();
-    }
+    return Message.builder()
+        .message("비밀번호가 변경되었습니다.").build();
+  }
 
-    @Override
-    @Transactional
-    public Message deleteCurrentShopOwner(UserPrincipal userPrincipal) {
-        ShopOwner shopOwner = shopOwnerRepository.findById(userPrincipal.getId())
-                .orElseThrow(InvalidShopOwnerException::new);
-        Token token = tokenRepository.findByUserEmail(userPrincipal.getEmail())
-                .orElseThrow(InvalidTokenException::new);
+  @Override
+  @Transactional
+  public Message deleteCurrentShopOwner(UserPrincipal userPrincipal) {
+    ShopOwner shopOwner = shopOwnerRepository.findById(userPrincipal.getId())
+        .orElseThrow(InvalidShopOwnerException::new);
+    Token token = tokenRepository.findByUserEmail(userPrincipal.getEmail())
+        .orElseThrow(InvalidTokenException::new);
 
-        shopOwner.updateStatus(Status.DELETE);
-        tokenRepository.delete(token);
+    shopOwner.updateStatus(Status.DELETE);
+    tokenRepository.delete(token);
 
-        return Message.builder()
-                .message("사장 탈퇴가 완료되었습니다.")
-                .build();
-    }
+    return Message.builder()
+        .message("사장 탈퇴가 완료되었습니다.")
+        .build();
+  }
+
+  public ShopOwnerGiftManageRes getShopOwnerReservation(UserPrincipal userPrincipal, Long giftId) {
+    List<Reservation> reservationList = reservationRepository.findAllByExperienceGift_IdAndStatus(giftId);
+    ExperienceGift experienceGift = experienceGiftRepository.findByExperienceGiftId(giftId)
+        .orElseThrow(
+            ExperienceGiftNotFoundException::new);
+    return ShopOwnerGiftManageRes.builder()
+        .reservationList(ShopOwnerReservationRes.from(reservationList))
+        .subTitle(experienceGift.getSubtitle().getTitle())
+        .title(experienceGift.getTitle())
+        .build();
+  }
 
 }

--- a/src/main/java/com/shallwe/domain/shopowner/domain/ShopOwner.java
+++ b/src/main/java/com/shallwe/domain/shopowner/domain/ShopOwner.java
@@ -1,10 +1,13 @@
 package com.shallwe.domain.shopowner.domain;
 
 import com.shallwe.domain.common.BaseEntity;
+import com.shallwe.domain.reservation.domain.Reservation;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.Where;
 
@@ -26,6 +29,9 @@ public class ShopOwner extends BaseEntity {
     private String password;
 
     private Boolean marketingConsent;
+
+    @OneToMany
+    private List<Reservation> reservationList;
 
     public void changePassword(String password) {
         this.password = password;

--- a/src/main/java/com/shallwe/domain/shopowner/dto/ShopOwnerGiftManageRes.java
+++ b/src/main/java/com/shallwe/domain/shopowner/dto/ShopOwnerGiftManageRes.java
@@ -1,0 +1,21 @@
+package com.shallwe.domain.shopowner.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class ShopOwnerGiftManageRes {
+
+  private String title;
+  private String subTitle;
+  private List<ShopOwnerReservationRes> reservationList;
+
+  public ShopOwnerGiftManageRes(String title, String subTitle,
+      List<ShopOwnerReservationRes> reservationList) {
+    this.title = title;
+    this.subTitle = subTitle;
+    this.reservationList = reservationList;
+  }
+}

--- a/src/main/java/com/shallwe/domain/shopowner/dto/ShopOwnerReservationRes.java
+++ b/src/main/java/com/shallwe/domain/shopowner/dto/ShopOwnerReservationRes.java
@@ -1,0 +1,40 @@
+package com.shallwe.domain.shopowner.dto;
+
+import com.shallwe.domain.reservation.domain.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+public class ShopOwnerReservationRes {
+
+  private String sender;
+  private LocalDate date;
+  private LocalTime time;
+  private String phoneNum;
+  private Long person;
+
+  @Builder
+  public ShopOwnerReservationRes(String sender, LocalDate date, LocalTime time, String phoneNum,
+      Long person) {
+    this.sender = sender;
+    this.date = date;
+    this.time = time;
+    this.phoneNum = phoneNum;
+    this.person = person;
+  }
+
+  public static List<ShopOwnerReservationRes> from(List<Reservation> reservationList) {
+    return reservationList.stream()
+        .map(reservation -> ShopOwnerReservationRes.builder()
+            .date(reservation.getDate())
+            .person(reservation.getPersons())
+            .phoneNum(reservation.getPhoneNumber())
+            .sender(reservation.getSender().getName())
+            .time(reservation.getTime())
+            .build()).toList();
+  }
+}

--- a/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
+++ b/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
@@ -3,6 +3,7 @@ package com.shallwe.domain.shopowner.presentation;
 
 import com.shallwe.domain.shopowner.application.ShopOwnerServiceImpl;
 import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
+import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
 import com.shallwe.domain.user.dto.DeleteUserRes;
 import com.shallwe.global.config.security.token.CurrentUser;
 import com.shallwe.global.config.security.token.UserPrincipal;
@@ -52,4 +53,16 @@ public class ShopOwnerController {
         return ResponseCustom.OK(shopOwnerService.deleteCurrentShopOwner(userPrincipal));
     }
 
+    @Operation(summary = "사장 예약 조회", description = "사장이 등록한 상품의 예약을 조회 합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "상품 예약 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+        @ApiResponse(responseCode = "400", description = "상품 예약 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping
+    public ResponseCustom<ShopOwnerGiftManageRes> getCurrentGiftReservation(
+        @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+        @Parameter(description = "상품 ID를 입력해주세요", required = true) @RequestHeader Long giftId
+    ) {
+        return ResponseCustom.OK(shopOwnerService.getShopOwnerReservation(userPrincipal,giftId));
+    }
 }

--- a/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
+++ b/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
@@ -4,7 +4,6 @@ package com.shallwe.domain.shopowner.presentation;
 import com.shallwe.domain.shopowner.application.ShopOwnerServiceImpl;
 import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
-import com.shallwe.domain.user.dto.DeleteUserRes;
 import com.shallwe.global.config.security.token.CurrentUser;
 import com.shallwe.global.config.security.token.UserPrincipal;
 import com.shallwe.global.payload.ErrorResponse;
@@ -26,43 +25,65 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/shop-owners")
 public class ShopOwnerController {
 
-    private final ShopOwnerServiceImpl shopOwnerService;
+  private final ShopOwnerServiceImpl shopOwnerService;
 
-    @Operation(summary = "사장 비밀번호 변경(토큰 필요)", description = "사장 비밀번호 변경을 수행합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사장 비밀번호 변경 성공", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class) ) } ),
-            @ApiResponse(responseCode = "400", description = "사장 비밀번호 변경 실패", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class) ) } ),
-    })
-    @PatchMapping(value="/change-password")
-    public ResponseCustom<Message> shopOwnerChangePassword(
-            @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "ShopOwnerChangePasswordReq Schema를 확인해주세요.", required = true) @RequestBody ShopOwnerChangePasswordReq shopOwnerChangePasswordReq
-            ) {
-        return ResponseCustom.OK(shopOwnerService.shopOwnerChangePassword(userPrincipal, shopOwnerChangePasswordReq));
-    }
+  @Operation(summary = "사장 비밀번호 변경(토큰 필요)", description = "사장 비밀번호 변경을 수행합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사장 비밀번호 변경 성공", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+      @ApiResponse(responseCode = "400", description = "사장 비밀번호 변경 실패", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+  })
+  @PatchMapping(value = "/change-password")
+  public ResponseCustom<Message> shopOwnerChangePassword(
+      @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+      @Parameter(description = "ShopOwnerChangePasswordReq Schema를 확인해주세요.", required = true) @RequestBody ShopOwnerChangePasswordReq shopOwnerChangePasswordReq
+  ) {
+    return ResponseCustom.OK(
+        shopOwnerService.shopOwnerChangePassword(userPrincipal, shopOwnerChangePasswordReq));
+  }
 
-    @Operation(summary = "사장 탈퇴", description = "사장 탈퇴를 수행합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사장 탈퇴 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
-            @ApiResponse(responseCode = "400", description = "사장 탈퇴 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-    })
-    @PatchMapping
-    public ResponseCustom<Message> deleteCurrentShopOwner(
-            @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
-    ) {
-        return ResponseCustom.OK(shopOwnerService.deleteCurrentShopOwner(userPrincipal));
-    }
+  @Operation(summary = "사장 탈퇴", description = "사장 탈퇴를 수행합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사장 탈퇴 성공", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+      @ApiResponse(responseCode = "400", description = "사장 탈퇴 실패", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+  })
+  @PatchMapping
+  public ResponseCustom<Message> deleteCurrentShopOwner(
+      @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+  ) {
+    return ResponseCustom.OK(shopOwnerService.deleteCurrentShopOwner(userPrincipal));
+  }
 
-    @Operation(summary = "사장 예약 조회", description = "사장이 등록한 상품의 예약을 조회 합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상품 예약 조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
-        @ApiResponse(responseCode = "400", description = "상품 예약 조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-    })
-    @GetMapping
-    public ResponseCustom<ShopOwnerGiftManageRes> getCurrentGiftReservation(
-        @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-        @Parameter(description = "상품 ID를 입력해주세요", required = true) @RequestHeader Long giftId
-    ) {
-        return ResponseCustom.OK(shopOwnerService.getShopOwnerReservation(userPrincipal,giftId));
-    }
+  @Operation(summary = "사장 예약 조회", description = "사장이 등록한 상품의 예약을 조회 합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "상품 예약 조회 성공", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+      @ApiResponse(responseCode = "400", description = "상품 예약 조회 실패", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+  })
+  @GetMapping
+  public ResponseCustom<ShopOwnerGiftManageRes> getCurrentGiftReservation(
+      @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+      @Parameter(description = "상품 ID를 입력해주세요", required = true) @RequestHeader Long giftId
+  ) {
+    return ResponseCustom.OK(shopOwnerService.getShopOwnerReservation(userPrincipal, giftId));
+  }
+
+  @Operation(summary = "예약 확정", description = "유저 결제 확인 후 예약을 확정상태로 변경합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "예약 확정 성공", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+      @ApiResponse(responseCode = "400", description = "예약 확정 실패", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+  })
+  @GetMapping
+  public ResponseCustom<Message> confirmReservationPayment(
+      @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+      @Parameter(description = "예약 ID를 입력해주세요", required = true) @RequestHeader Long reservationId
+  ) {
+    return ResponseCustom.OK(shopOwnerService.confirmPayment(userPrincipal, reservationId));
+  }
 }

--- a/src/main/java/com/shallwe/domain/user/dto/ReceiveGiftDetailRes.java
+++ b/src/main/java/com/shallwe/domain/user/dto/ReceiveGiftDetailRes.java
@@ -1,6 +1,8 @@
 package com.shallwe.domain.user.dto;
 
 import com.shallwe.domain.reservation.domain.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,7 +17,8 @@ public class ReceiveGiftDetailRes {
     private Long reservationId;
     private String experienceTitle;
     private String experienceSubTitle;
-    private LocalDateTime dateTime;
+    private LocalDate date;
+    private LocalTime time;
     private UserDetailRes sender;
     private String invitationImg;
     private String invitationComment;
@@ -25,7 +28,8 @@ public class ReceiveGiftDetailRes {
                 .reservationId(reservation.getId())
                 .experienceTitle(reservation.getExperienceGift().getTitle())
                 .experienceSubTitle(reservation.getExperienceGift().getSubtitle().getTitle())
-                .dateTime(reservation.getDate())
+                .date(reservation.getDate())
+                .time(reservation.getTime())
                 .sender(UserDetailRes.toDto(reservation.getSender()))
                 .invitationImg(reservation.getInvitationImg())
                 .invitationComment(reservation.getInvitationComment())

--- a/src/main/java/com/shallwe/domain/user/dto/SendGiftDetailRes.java
+++ b/src/main/java/com/shallwe/domain/user/dto/SendGiftDetailRes.java
@@ -1,6 +1,8 @@
 package com.shallwe.domain.user.dto;
 
 import com.shallwe.domain.reservation.domain.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,24 +14,26 @@ import java.time.LocalDateTime;
 @Builder
 public class SendGiftDetailRes {
 
-    private Long reservationId;
-    private String experienceTitle;
-    private String experienceSubTitle;
-    private LocalDateTime dateTime;
-    private UserDetailRes receiver;
-    private String invitationImg;
-    private String invitationComment;
+  private Long reservationId;
+  private String experienceTitle;
+  private String experienceSubTitle;
+  private LocalDate date;
+  private LocalTime time;
+  private UserDetailRes receiver;
+  private String invitationImg;
+  private String invitationComment;
 
-    public static SendGiftDetailRes toDto(Reservation reservation) {
-        return SendGiftDetailRes.builder()
-                .reservationId(reservation.getId())
-                .experienceTitle(reservation.getExperienceGift().getTitle())
-                .experienceSubTitle(reservation.getExperienceGift().getSubtitle().getTitle())
-                .dateTime(reservation.getDate())
-                .receiver(UserDetailRes.toDto(reservation.getReceiver()))
-                .invitationImg(reservation.getInvitationImg())
-                .invitationComment(reservation.getInvitationComment())
-                .build();
-    }
+  public static SendGiftDetailRes toDto(Reservation reservation) {
+    return SendGiftDetailRes.builder()
+        .reservationId(reservation.getId())
+        .experienceTitle(reservation.getExperienceGift().getTitle())
+        .experienceSubTitle(reservation.getExperienceGift().getSubtitle().getTitle())
+        .date(reservation.getDate())
+        .time(reservation.getTime())
+        .receiver(UserDetailRes.toDto(reservation.getReceiver()))
+        .invitationImg(reservation.getInvitationImg())
+        .invitationComment(reservation.getInvitationComment())
+        .build();
+  }
 
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용

기존 작업한 내용과 다르게 사장님이 날짜와 시간을 선택하면, 해당 날짜로 설정된 예약을 모두 생성한 후, 상태를 Waiting 으로 변경합니다.
후, 유저가 상품을 예약하고 싶다면, Waiting 상태인 예약만 이용할 수 있도록 변경하였습니다. 

이점 : 테이블을 추가적으로 두고 join 하며 상품의 가능 예약 시간대를 탐색하지 않아, 속도 향상
단점 : 한번 상품 등록 시 생성되는 예약의 수가 많아집니다. 


## 스크린샷

### 사장님이 시간 선택 후 요청 전송

![스크린샷 2023-11-11 오후 11 29 09](https://github.com/ShallWeProject/ShallWeProject_Server/assets/43662405/2b51472e-7b24-471a-aef2-1afd532eab6f)

### JSON 요청 예시
![스크린샷 2023-11-11 오후 11 29 45](https://github.com/ShallWeProject/ShallWeProject_Server/assets/43662405/337a35b4-58c7-4dc1-b5e2-812b5efb6fa2)

### JSON 응답 예시 
![스크린샷 2023-11-11 오후 11 30 11](https://github.com/ShallWeProject/ShallWeProject_Server/assets/43662405/e7f80d3e-8ec9-4cf1-8e72-374d2daa7f35)


## 주의사항

의견 알려주시면 빠르게 다른 기능 추가해서 완료하겠습니다

Closes #147 