### PR TITLE
[FIX] 사장님 비밀번호 변경 API Auth 도메인으로 이동

### DIFF
--- a/src/main/java/com/shallwe/domain/auth/application/AuthService.java
+++ b/src/main/java/com/shallwe/domain/auth/application/AuthService.java
@@ -7,8 +7,10 @@ import com.shallwe.domain.auth.exception.AlreadyExistEmailException;
 import com.shallwe.domain.auth.exception.InvalidPasswordException;
 import com.shallwe.domain.shopowner.domain.ShopOwner;
 import com.shallwe.domain.shopowner.domain.repository.ShopOwnerRepository;
+import com.shallwe.domain.auth.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.domain.shopowner.exception.AlreadyExistPhoneNumberException;
 import com.shallwe.domain.shopowner.exception.InvalidPhoneNumberException;
+import com.shallwe.domain.shopowner.exception.InvalidShopOwnerException;
 import com.shallwe.domain.user.exception.InvalidUserException;
 import com.shallwe.global.DefaultAssert;
 
@@ -223,6 +225,18 @@ public class AuthService {
                 .build();
 
         return authRes;
+    }
+
+    @Transactional
+    public Message shopOwnerChangePassword(final ShopOwnerChangePasswordReq shopOwnerChangePasswordReq) {
+        ShopOwner shopOwner = shopOwnerRepository.findShopOwnerByPhoneNumber(shopOwnerChangePasswordReq.getPhoneNumber())
+                .orElseThrow(InvalidShopOwnerException::new);
+
+        shopOwner.changePassword(
+                passwordEncoder.encode(shopOwnerChangePasswordReq.getChangePassword()));
+
+        return Message.builder()
+                .message("비밀번호가 변경되었습니다.").build();
     }
 
     private boolean valid(final String refreshToken) {

--- a/src/main/java/com/shallwe/domain/auth/dto/ShopOwnerChangePasswordReq.java
+++ b/src/main/java/com/shallwe/domain/auth/dto/ShopOwnerChangePasswordReq.java
@@ -1,10 +1,13 @@
-package com.shallwe.domain.shopowner.dto;
+package com.shallwe.domain.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
 public class ShopOwnerChangePasswordReq {
+
+    @Schema( type = "string", example = "01012345678" , description="사장의 핸드폰 번호입니다.")
+    private String phoneNumber;
 
     @Schema( type = "string", example = "asdfqwer1234!@#$" , description="사장의 변경할 비밀번호입니다.")
     private String changePassword;

--- a/src/main/java/com/shallwe/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/shallwe/domain/auth/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.shallwe.domain.auth.presentation;
 
 
 import com.shallwe.domain.auth.application.SmsService;
+import com.shallwe.domain.auth.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.global.payload.ResponseCustom;
 import jakarta.validation.Valid;
 
@@ -9,18 +10,10 @@ import com.shallwe.domain.auth.dto.*;
 import com.shallwe.global.payload.ErrorResponse;
 import com.shallwe.global.config.security.token.CurrentUser;
 import com.shallwe.global.config.security.token.UserPrincipal;
-import com.shallwe.domain.user.domain.User;
 import com.shallwe.global.payload.Message;
 import com.shallwe.domain.auth.application.AuthService;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -149,6 +142,21 @@ public class AuthController {
             @Parameter(description = "Schemas의 RefreshTokenRequest를 참고해주세요.", required = true) @Valid @RequestBody RefreshTokenReq tokenRefreshRequest
     ) {
         return ResponseCustom.OK(authService.signOut(tokenRefreshRequest));
+    }
+
+    @Operation(summary = "사장 비밀번호 변경", description = "사장 비밀번호 변경을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사장 비밀번호 변경 성공", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "사장 비밀번호 변경 실패", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PatchMapping(value = "/shop-owner/change-password")
+    public ResponseCustom<Message> shopOwnerChangePassword(
+            @Parameter(description = "ShopOwnerChangePasswordReq Schema를 확인해주세요.", required = true) @RequestBody ShopOwnerChangePasswordReq shopOwnerChangePasswordReq
+    ) {
+        return ResponseCustom.OK(
+                authService.shopOwnerChangePassword(shopOwnerChangePasswordReq));
     }
 
 }

--- a/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerService.java
+++ b/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerService.java
@@ -1,16 +1,14 @@
 package com.shallwe.domain.shopowner.application;
 
-import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
-import com.shallwe.domain.user.dto.DeleteUserRes;
 import com.shallwe.global.config.security.token.UserPrincipal;
 import com.shallwe.global.payload.Message;
 
 public interface ShopOwnerService {
 
-    Message shopOwnerChangePassword(UserPrincipal userPrincipal, ShopOwnerChangePasswordReq shopOwnerChangePasswordReq);
     Message deleteCurrentShopOwner(UserPrincipal userPrincipal);
     ShopOwnerGiftManageRes getShopOwnerReservation(UserPrincipal userPrincipal, Long giftId);
     Message confirmPayment(UserPrincipal userPrincipal, Long reservationId);
+
 }
 

--- a/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerServiceImpl.java
+++ b/src/main/java/com/shallwe/domain/shopowner/application/ShopOwnerServiceImpl.java
@@ -16,7 +16,6 @@ import com.shallwe.domain.reservation.exception.InvalidReservationException;
 import com.shallwe.domain.shopowner.domain.ShopOwner;
 import com.shallwe.domain.shopowner.domain.repository.ShopOwnerRepository;
 import com.shallwe.domain.shopowner.dto.ShopOwnerReservationRes;
-import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
 import com.shallwe.domain.shopowner.exception.InvalidShopOwnerException;
 import com.shallwe.domain.user.exception.InvalidTokenException;
@@ -39,19 +38,6 @@ public class ShopOwnerServiceImpl implements ShopOwnerService {
   private final ReservationRepository reservationRepository;
   private final ExperienceGiftRepository experienceGiftRepository;
 
-  @Override
-  @Transactional
-  public Message shopOwnerChangePassword(final UserPrincipal userPrincipal,
-      final ShopOwnerChangePasswordReq shopOwnerChangePasswordReq) {
-    ShopOwner shopOwner = shopOwnerRepository.findById(userPrincipal.getId())
-        .orElseThrow(InvalidShopOwnerException::new);
-
-    shopOwner.changePassword(
-        passwordEncoder.encode(shopOwnerChangePasswordReq.getChangePassword()));
-
-    return Message.builder()
-        .message("비밀번호가 변경되었습니다.").build();
-  }
 
   @Override
   @Transactional

--- a/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
+++ b/src/main/java/com/shallwe/domain/shopowner/presentation/ShopOwnerController.java
@@ -2,7 +2,6 @@ package com.shallwe.domain.shopowner.presentation;
 
 
 import com.shallwe.domain.shopowner.application.ShopOwnerServiceImpl;
-import com.shallwe.domain.shopowner.dto.ShopOwnerChangePasswordReq;
 import com.shallwe.domain.shopowner.dto.ShopOwnerGiftManageRes;
 import com.shallwe.global.config.security.token.CurrentUser;
 import com.shallwe.global.config.security.token.UserPrincipal;
@@ -26,22 +25,6 @@ import org.springframework.web.bind.annotation.*;
 public class ShopOwnerController {
 
   private final ShopOwnerServiceImpl shopOwnerService;
-
-  @Operation(summary = "사장 비밀번호 변경(토큰 필요)", description = "사장 비밀번호 변경을 수행합니다.")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "사장 비밀번호 변경 성공", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
-      @ApiResponse(responseCode = "400", description = "사장 비밀번호 변경 실패", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-  })
-  @PatchMapping(value = "/change-password")
-  public ResponseCustom<Message> shopOwnerChangePassword(
-      @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-      @Parameter(description = "ShopOwnerChangePasswordReq Schema를 확인해주세요.", required = true) @RequestBody ShopOwnerChangePasswordReq shopOwnerChangePasswordReq
-  ) {
-    return ResponseCustom.OK(
-        shopOwnerService.shopOwnerChangePassword(userPrincipal, shopOwnerChangePasswordReq));
-  }
 
   @Operation(summary = "사장 탈퇴", description = "사장 탈퇴를 수행합니다.")
   @ApiResponses(value = {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
- 기존에 토큰이 필요했던 사장 비밀번호 변경 API를 토큰이 필요없에 변경
- URL 변경 되었습니다. 기존 : /api/v1/shop-owers/change-password => /auth/shop-owner/change-password
## 스크린샷
![image](https://github.com/ShallWeProject/ShallWeProject_Server/assets/95167215/f7a9ba19-1031-4fbd-8cb8-090fbd1e2af3)

## 주의사항

Closes #{이슈 번호}