### PR TITLE
[Fix] 썸네일 사진 여려장 첨부 가능하도록 로직 수정

### DIFF
--- a/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftService.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftService.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 
 public interface ExperienceGiftService {
 
-    ExperienceDetailRes createExperience(final UserPrincipal userPrincipal,final ExperienceReq experienceReq);
-
     List<ExperienceRes> searchExperience(UserPrincipal userPrincipal,String title);
 
     ExperienceDetailRes getExperienceDetails(final UserPrincipal userPrincipal,Long ExperienceGiftId);

--- a/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftServiceImpl.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/application/ExperienceGiftServiceImpl.java
@@ -16,6 +16,7 @@ import com.shallwe.domain.shopowner.exception.InvalidShopOwnerException;
 import com.shallwe.domain.user.domain.repository.UserRepository;
 import com.shallwe.domain.user.exception.InvalidUserException;
 import com.shallwe.global.config.security.token.UserPrincipal;
+import com.shallwe.global.utils.AwsS3ImageUrlUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +40,7 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
     private final ExplanationRepository explanationRepository;
     private final ShopOwnerRepository shopOwnerRepository;
     private final ReservationRepository reservationRepository;
+    private final ExperienceGiftImgRepository experienceGiftImgRepository;
 
 
     @Override
@@ -54,9 +56,15 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
 
         List<ExperienceGift> popularGifts = experienceGiftRepository.findAllPopularGifts();
-        return popularGifts.stream()
-                .map(ExperienceRes::toDto)
-                .collect(Collectors.toList());
+
+        return popularGifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
@@ -98,6 +106,13 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
 
         explanationRepository.saveAll(explanations);
 
+        List<ExperienceGiftImg> imgList = adminExperienceReq.getGiftImgKey().stream()
+                .map(imgKey -> new ExperienceGiftImg(null, experienceGift, AwsS3ImageUrlUtil.toUrl(imgKey)))
+                .collect(Collectors.toList());
+
+        experienceGiftImgRepository.saveAll(imgList);
+
+
     }
 
     @Override
@@ -128,24 +143,21 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
                 .collect(Collectors.toList());
     }
 
-    @Override
-    @Transactional
-    public ExperienceDetailRes createExperience(UserPrincipal userPrincipal,ExperienceReq experienceReq ) {
-        userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        ExperienceGift experienceGift = ExperienceReq.toEntity(experienceReq,
-                subtitleRepository.findBySubtitleId(experienceReq.getSubtitleId()).orElseThrow(SubtitleNotFoundException::new),
-                expCategoryRepository.findByExpCategoryId(experienceReq.getExpCategoryId()).orElseThrow(ExpCategoryNotFoundException::new),
-                sttCategoryRepository.findBySttCategoryId(experienceReq.getSttCategoryId()).orElseThrow(SttCategoryNotFoundException::new)
-        );
-        ExperienceGift savedGift = experienceGiftRepository.save(experienceGift);
-        return ExperienceDetailRes.toDto(savedGift);
-    }
+
 
     @Override
     public List<ExperienceRes> searchExperience(UserPrincipal userPrincipal, String title) {
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return experienceGiftRepository.findByTitleContains(title)
-                .stream().map(ExperienceRes::toDto).collect(Collectors.toList());
+        List<ExperienceGift> experienceGifts = experienceGiftRepository.findByTitleContains(title);
+
+        return experienceGifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
@@ -153,36 +165,74 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
         ExperienceGift experienceGift=experienceGiftRepository.findByExperienceGiftId(ExperienceGiftId).orElseThrow(ExperienceGiftNotFoundException::new);
         List<Explanation> explanations=explanationRepository.findByExperienceGift(experienceGift);
-        return ExperienceDetailRes.toDetailDto(experienceGift,explanations);
+
+        List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+        List<String> imgUrls = giftImgs.stream()
+                .map(ExperienceGiftImg::getImgKey)
+                .collect(Collectors.toList());
+
+        return ExperienceDetailRes.toDetailDto(experienceGift,explanations,imgUrls);
 
     }
 
     @Override
-    public List<ExperienceSttCategoryRes> highSttCategoryPricedGift(UserPrincipal userPrincipal,Long SttCategoryId) {
+    public List<ExperienceSttCategoryRes> highSttCategoryPricedGift(UserPrincipal userPrincipal,Long sttCategoryId) {
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return experienceGiftRepository.findGiftsBySttCategoryIdOrderByPriceDesc(SttCategoryId)
-                .stream().map(ExperienceSttCategoryRes::toDto).collect(Collectors.toList());
+        List<ExperienceGift> gifts = experienceGiftRepository.findGiftsBySttCategoryIdOrderByPriceDesc(sttCategoryId);
+
+        return gifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceSttCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
-    public List<ExperienceSttCategoryRes> lowSttCategoryPricedGift(UserPrincipal userPrincipal, Long SttCategoryId) {
+    public List<ExperienceSttCategoryRes> lowSttCategoryPricedGift(UserPrincipal userPrincipal, Long sttCategoryId) {
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return experienceGiftRepository.findGiftsBySttCategoryIdOrderByPriceAsc(SttCategoryId)
-                .stream().map(ExperienceSttCategoryRes::toDto).collect(Collectors.toList());
+        List<ExperienceGift> gifts = experienceGiftRepository.findGiftsBySttCategoryIdOrderByPriceAsc(sttCategoryId);
+
+        return gifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceSttCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
-    public List<ExperienceExpCategoryRes> highExpCategoryPricedGift(UserPrincipal userPrincipal, Long ExpCategoryId) {
+    public List<ExperienceExpCategoryRes> highExpCategoryPricedGift(UserPrincipal userPrincipal, Long expCategoryId) {
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return experienceGiftRepository.findGiftsByExpCategoryIdOrderByPriceDesc(ExpCategoryId)
-                .stream().map(ExperienceExpCategoryRes::toDto).collect(Collectors.toList());
+        List<ExperienceGift> gifts = experienceGiftRepository.findGiftsByExpCategoryIdOrderByPriceDesc(expCategoryId);
+
+        return gifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceExpCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
-    public List<ExperienceExpCategoryRes> lowExpCategoryPricedGift(UserPrincipal userPrincipal, Long ExpCategoryId) {
+    public List<ExperienceExpCategoryRes> lowExpCategoryPricedGift(UserPrincipal userPrincipal, Long expCategoryId) {
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
-        return experienceGiftRepository.findGiftsByExpCategoryIdOrderByPriceAsc(ExpCategoryId)
-                .stream().map(ExperienceExpCategoryRes::toDto).collect(Collectors.toList());
+        List<ExperienceGift> gifts = experienceGiftRepository.findGiftsByExpCategoryIdOrderByPriceAsc(expCategoryId);
+
+        return gifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceExpCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
@@ -190,9 +240,14 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
 
         List<ExperienceGift> popularGifts = experienceGiftRepository.findPopularGiftsBySttCategoryId(sttCategoryId);
-        return popularGifts.stream()
-                .map(ExperienceSttCategoryRes::toDto)
-                .collect(Collectors.toList());
+        return popularGifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceSttCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
     @Override
@@ -200,9 +255,14 @@ public class ExperienceGiftServiceImpl implements ExperienceGiftService{
         userRepository.findById(userPrincipal.getId()).orElseThrow(InvalidUserException::new);
 
         List<ExperienceGift> popularGifts = experienceGiftRepository.findPopularGiftsByExpCategoryId(expCategoryId);
-        return popularGifts.stream()
-                .map(ExperienceExpCategoryRes::toDto)
-                .collect(Collectors.toList());
+        return popularGifts.stream().map(experienceGift -> {
+            List<ExperienceGiftImg> giftImgs = experienceGiftImgRepository.findByExperienceGift(experienceGift);
+            List<String> imgUrls = giftImgs.stream()
+                    .map(ExperienceGiftImg::getImgKey)
+                    .collect(Collectors.toList());
+
+            return ExperienceExpCategoryRes.toDto(experienceGift, imgUrls);
+        }).collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGift.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGift.java
@@ -8,6 +8,9 @@ import com.shallwe.global.utils.AwsS3ImageUrlUtil;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -45,11 +48,13 @@ public class ExperienceGift extends BaseEntity {
 
     private String location;
 
+    @OneToMany(mappedBy = "experienceGift")
+    private List<ExperienceGiftImg> imgList=new ArrayList<>();
+
     public static ExperienceGift toDto(AdminExperienceReq req, Subtitle subtitle, ExpCategory expCategory, SttCategory sttCategory, ShopOwner shopOwner) {
         return ExperienceGift.builder()
                 .title(req.getTitle())
                 .subtitle(subtitle)
-                .thumbnail(AwsS3ImageUrlUtil.toUrl(req.getGiftImgUrl()))
                 .price(req.getPrice())
                 .expCategory(expCategory)
                 .sttCategory(sttCategory)

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGiftImg.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/ExperienceGiftImg.java
@@ -1,0 +1,23 @@
+package com.shallwe.domain.experiencegift.domain;
+
+import com.shallwe.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class ExperienceGiftImg extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long experienceGiftImgId;
+
+    @ManyToOne
+    @JoinColumn(nullable = false,name = "experienceGift_id")
+    private ExperienceGift experienceGift;
+
+    private String imgKey;
+
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/domain/repository/ExperienceGiftImgRepository.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/domain/repository/ExperienceGiftImgRepository.java
@@ -1,0 +1,11 @@
+package com.shallwe.domain.experiencegift.domain.repository;
+
+import com.shallwe.domain.experiencegift.domain.ExperienceGift;
+import com.shallwe.domain.experiencegift.domain.ExperienceGiftImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExperienceGiftImgRepository extends JpaRepository<ExperienceGiftImg,Long> {
+    List<ExperienceGiftImg> findByExperienceGift(ExperienceGift experienceGift);
+}

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/request/AdminExperienceReq.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/request/AdminExperienceReq.java
@@ -1,5 +1,7 @@
 package com.shallwe.domain.experiencegift.dto.request;
 
+import com.shallwe.domain.experiencegift.domain.ExperienceGift;
+import com.shallwe.domain.experiencegift.domain.ExperienceGiftImg;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -29,7 +31,7 @@ public class AdminExperienceReq {
     private String subtitle;
 
     @Schema(type = "String", description = "썸네일")
-    private String giftImgUrl;
+    private List<String> giftImgKey;
 
     @Schema(type = "String", description = "상품 설명", maxLength = 256)
     @NotBlank(message = "상품 설명은 필수 입력 값입니다.")

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceDetailRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceDetailRes.java
@@ -17,9 +17,8 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class ExperienceDetailRes {
 
-    private String giftImgUrl;
+    private List<String> giftImgUrl;
     private Long ExperienceGiftId;
-    private String thumbnail;
     private String title;
     private String subtitle;
     private Long price;
@@ -28,25 +27,23 @@ public class ExperienceDetailRes {
     private String expCategory;
     private String sttCategory;
 
-    public static ExperienceDetailRes toDto(ExperienceGift experienceGift){
+    public static ExperienceDetailRes toDto(ExperienceGift experienceGift,List<String> giftImgUrl){
         return ExperienceDetailRes.builder()
                 .ExperienceGiftId(experienceGift.getExperienceGiftId())
                 .title(experienceGift.getTitle())
-                .thumbnail(experienceGift.getThumbnail())
                 .price(experienceGift.getPrice())
                 .description(experienceGift.getDescription())
                 .subtitle(experienceGift.getSubtitle().getTitle())
                 .expCategory(experienceGift.getExpCategory().getExpCategory())
                 .sttCategory(experienceGift.getSttCategory().getSttCategory())
-                .giftImgUrl(experienceGift.getGiftImgKey())
+                .giftImgUrl(giftImgUrl)
                 .build();
     }
 
-    public static ExperienceDetailRes toDetailDto(ExperienceGift experienceGift, List<Explanation> explanations){
+    public static ExperienceDetailRes toDetailDto(ExperienceGift experienceGift, List<Explanation> explanations,List<String> giftImgUrl){
         ExperienceDetailRes experienceDetailRes=new ExperienceDetailRes();
         experienceDetailRes.ExperienceGiftId=experienceGift.getExperienceGiftId();
-        experienceDetailRes.giftImgUrl= AwsS3ImageUrlUtil.toUrl(experienceGift.getGiftImgKey());
-        experienceDetailRes.thumbnail=experienceGift.getThumbnail();
+        experienceDetailRes.giftImgUrl= giftImgUrl;
         experienceDetailRes.title=experienceGift.getTitle();
         experienceDetailRes.subtitle=experienceGift.getSubtitle().getTitle();
         experienceDetailRes.price=experienceGift.getPrice();

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceExpCategoryRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceExpCategoryRes.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @Builder
@@ -15,21 +17,19 @@ public class ExperienceExpCategoryRes {
 
     private Long expCategoryId;
     private Long ExperienceGiftId;
-    private String thumbnail;
     private String subtitleTitle;
     private String title;
     private Long price;
-    private String giftImgUrl;
+    private List<String> giftImgUrl;
 
-    public static ExperienceExpCategoryRes toDto(ExperienceGift experienceGift){
+    public static ExperienceExpCategoryRes toDto(ExperienceGift experienceGift,List<String> giftImgUrl){
         return ExperienceExpCategoryRes.builder()
                 .expCategoryId(experienceGift.getExpCategory().getExpCategoryId())
                 .ExperienceGiftId(experienceGift.getExperienceGiftId())
-                .thumbnail(experienceGift.getThumbnail())
                 .subtitleTitle(experienceGift.getSubtitle().getTitle())
                 .title(experienceGift.getTitle())
                 .price(experienceGift.getPrice())
-                .giftImgUrl(AwsS3ImageUrlUtil.toUrl(experienceGift.getGiftImgKey()))
+                .giftImgUrl(giftImgUrl)
                 .build();
     }
 

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceRes.java
@@ -1,11 +1,14 @@
 package com.shallwe.domain.experiencegift.dto.response;
 
 import com.shallwe.domain.experiencegift.domain.ExperienceGift;
+import com.shallwe.domain.experiencegift.domain.ExperienceGiftImg;
 import com.shallwe.global.utils.AwsS3ImageUrlUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -18,16 +21,16 @@ public class ExperienceRes {
     private String subtitle;
     private String title;
     private Long price;
-    private String giftImgUrl;
+    private List<String> giftImgUrl;
 
-    public static ExperienceRes toDto(ExperienceGift experienceGift){
+    public static ExperienceRes toDto(ExperienceGift experienceGift, List<String> experienceGiftImgs){
         return ExperienceRes.builder()
                 .ExperienceGiftId(experienceGift.getExperienceGiftId())
                 .thumbnail(experienceGift.getThumbnail())
                 .subtitle(experienceGift.getSubtitle().getTitle())
                 .title(experienceGift.getTitle())
                 .price(experienceGift.getPrice())
-                .giftImgUrl(AwsS3ImageUrlUtil.toUrl(experienceGift.getGiftImgKey()))
+                .giftImgUrl(experienceGiftImgs)
                 .build();
     }
 

--- a/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceSttCategoryRes.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/dto/response/ExperienceSttCategoryRes.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @Builder
@@ -15,21 +17,19 @@ public class ExperienceSttCategoryRes {
 
     private Long sttCategoryId;
     private Long ExperienceGiftId;
-    private String thumbnail;
     private String subtitleTitle;
     private String title;
     private Long price;
-    private String giftImgUrl;
+    private List<String> giftImgUrl;
 
-    public static ExperienceSttCategoryRes toDto(ExperienceGift experienceGift){
+    public static ExperienceSttCategoryRes toDto(ExperienceGift experienceGift,List<String> giftImgUrl){
         return ExperienceSttCategoryRes.builder()
                 .ExperienceGiftId(experienceGift.getSttCategory().getSttCategoryId())
                 .ExperienceGiftId(experienceGift.getExperienceGiftId())
-                .thumbnail(experienceGift.getThumbnail())
                 .subtitleTitle(experienceGift.getSubtitle().getTitle())
                 .title(experienceGift.getTitle())
                 .price(experienceGift.getPrice())
-                .giftImgUrl(AwsS3ImageUrlUtil.toUrl(experienceGift.getGiftImgKey()))
+                .giftImgUrl(giftImgUrl)
                 .build();
     }
 

--- a/src/main/java/com/shallwe/domain/experiencegift/presentation/ExperienceGiftController.java
+++ b/src/main/java/com/shallwe/domain/experiencegift/presentation/ExperienceGiftController.java
@@ -1,7 +1,6 @@
 package com.shallwe.domain.experiencegift.presentation;
 
 import com.shallwe.domain.experiencegift.application.ExperienceGiftServiceImpl;
-import com.shallwe.domain.experiencegift.dto.request.ExperienceReq;
 import com.shallwe.domain.experiencegift.dto.response.*;
 import com.shallwe.domain.experiencegift.exception.ExperienceGiftNotFoundException;
 import com.shallwe.global.config.Constant;
@@ -130,19 +129,4 @@ public class ExperienceGiftController {
             throw new ExperienceGiftNotFoundException();
         }
     }
-
-    @Operation(summary = "경험 선물 추가", description = "경험 선물을 추가합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "경험 선물 추가 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ExperienceDetailRes.class))}),
-            @ApiResponse(responseCode = "400", description = "경험 선물 추가 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-    })
-    @PostMapping
-    public ResponseCustom<ExperienceDetailRes> CreateExpGift(
-            @Parameter(description = "AccessToken 을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "예약 요청을 확인해주세요.", required = true) @RequestBody ExperienceReq reservationRequest
-    ) {
-        return ResponseCustom.OK(experienceGiftService.createExperience(userPrincipal, reservationRequest));
-    }
-
-
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
## 작업 내용
- 썸네일 사진 여려장 첨부 가능하도록 로직 수정
- ExperienceGiftImg테이블 추가->썸네일 이미지 리스트 저장할 테이블
- 요구사항에 해당되는 response, 서비스 로직 수정

## 스크린샷
-수정 api가 많아서 스크린샷은 따로 첨부하지 않겠습니다
## 주의사항

Closes #168 